### PR TITLE
Pass props unpacked

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dynamic-remote-component",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Allows you to dynamically load a component from a remote using webpack 5's module federation.",
   "keywords": [
     "react",

--- a/src/RemoteComponent.tsx
+++ b/src/RemoteComponent.tsx
@@ -8,7 +8,7 @@ import { getRemoteModuleId } from "./utils";
 export type RemoteComponentProps = RemoteModule & {
   unLoadScriptOnUnmount?: boolean;
   exportName?: "string";
-  props?: object;
+  //props?: object;
 };
 
 export const getModule = (remoteModule: RemoteModule) => {
@@ -53,13 +53,17 @@ export const useRemoteModule = (remoteModule: RemoteModule) => {
   return getModuleSuspended(remoteModule);
 };
 
-export const RemoteComponent: FC<RemoteComponentProps> = ({
-  unLoadScriptOnUnmount = true,
-  exportName = "default",
-  props = {},
-  ...remoteModule
-}) => {
-  const { [exportName]: Component } = getModuleSuspended(remoteModule);
+export const RemoteComponent = (
+  props: any
+  ) => {
+  const exportName = props.exportName ?? "default";
+  const {url, scope, module, ...rest} = props;
+  const remotemodule: RemoteModule = {
+    url: url,
+    scope: scope,
+    module: module,
+  };
+  const { [exportName]: Component } = getModuleSuspended(remotemodule);
 
-  return <Component {...props}/>;
+  return <Component {...rest}/>;
 };

--- a/src/RemoteComponent.tsx
+++ b/src/RemoteComponent.tsx
@@ -5,17 +5,14 @@ import { RemoteModule } from "./types";
 import { suspend } from "./suspend";
 import { getRemoteModuleId } from "./utils";
 
-export type RemoteComponentPropsWithoutProps = {
+export type RemoteComponentProps = {
   url: string;
   scope: string;
   module: string;
   unLoadScriptOnUnmount?: boolean;
   exportName?: string;
+  [otherProps: string]: any;
 };
-
-export type RemoteComponentProps = RemoteComponentPropsWithoutProps & {
-  [rest: string]: any;
-}
 
 export const getModule = (remoteModule: RemoteModule) => {
   window.remoteModuleDictionary = window.remoteModuleDictionary || {};
@@ -63,11 +60,10 @@ export const RemoteComponent: FC<RemoteComponentProps> = (
   {
     unLoadScriptOnUnmount=true,
     exportName="default",
-    children,
     url,
     scope,
     module,
-    ...props
+    ...propsAndChildren
   }
   ) => {
   const remoteModule: RemoteModule = {
@@ -77,5 +73,5 @@ export const RemoteComponent: FC<RemoteComponentProps> = (
   };
   const { [exportName]: Component } = getModuleSuspended(remoteModule);
 
-  return <Component {...props}/>;
+  return <Component {...propsAndChildren}/>;
 };

--- a/src/RemoteComponent.tsx
+++ b/src/RemoteComponent.tsx
@@ -5,11 +5,17 @@ import { RemoteModule } from "./types";
 import { suspend } from "./suspend";
 import { getRemoteModuleId } from "./utils";
 
-export type RemoteComponentProps = RemoteModule & {
+export type RemoteComponentPropsWithoutProps = {
+  url: string;
+  scope: string;
+  module: string;
   unLoadScriptOnUnmount?: boolean;
-  exportName?: "string";
-  //props?: object;
+  exportName?: string;
 };
+
+export type RemoteComponentProps = RemoteComponentPropsWithoutProps & {
+  [rest: string]: any;
+}
 
 export const getModule = (remoteModule: RemoteModule) => {
   window.remoteModuleDictionary = window.remoteModuleDictionary || {};
@@ -53,17 +59,23 @@ export const useRemoteModule = (remoteModule: RemoteModule) => {
   return getModuleSuspended(remoteModule);
 };
 
-export const RemoteComponent = (
-  props: any
+export const RemoteComponent: FC<RemoteComponentProps> = (
+  {
+    unLoadScriptOnUnmount=true,
+    exportName="default",
+    children,
+    url,
+    scope,
+    module,
+    ...props
+  }
   ) => {
-  const exportName = props.exportName ?? "default";
-  const {url, scope, module, ...rest} = props;
-  const remotemodule: RemoteModule = {
+  const remoteModule: RemoteModule = {
     url: url,
     scope: scope,
     module: module,
   };
-  const { [exportName]: Component } = getModuleSuspended(remotemodule);
+  const { [exportName]: Component } = getModuleSuspended(remoteModule);
 
-  return <Component {...rest}/>;
+  return <Component {...props}/>;
 };

--- a/src/RemoteComponent.tsx
+++ b/src/RemoteComponent.tsx
@@ -5,10 +5,7 @@ import { RemoteModule } from "./types";
 import { suspend } from "./suspend";
 import { getRemoteModuleId } from "./utils";
 
-export type RemoteComponentProps = {
-  url: string;
-  scope: string;
-  module: string;
+export type RemoteComponentProps = RemoteModule & {
   unLoadScriptOnUnmount?: boolean;
   exportName?: string;
   [otherProps: string]: any;

--- a/src/RemoteComponent.tsx
+++ b/src/RemoteComponent.tsx
@@ -8,6 +8,7 @@ import { getRemoteModuleId } from "./utils";
 export type RemoteComponentProps = RemoteModule & {
   unLoadScriptOnUnmount?: boolean;
   exportName?: "string";
+  props?: object;
 };
 
 export const getModule = (remoteModule: RemoteModule) => {
@@ -55,9 +56,10 @@ export const useRemoteModule = (remoteModule: RemoteModule) => {
 export const RemoteComponent: FC<RemoteComponentProps> = ({
   unLoadScriptOnUnmount = true,
   exportName = "default",
+  props = {},
   ...remoteModule
 }) => {
   const { [exportName]: Component } = getModuleSuspended(remoteModule);
 
-  return <Component />;
+  return <Component {...props}/>;
 };

--- a/test/app1/src/App.tsx
+++ b/test/app1/src/App.tsx
@@ -18,7 +18,6 @@ function App() {
     scope="app2"
     module="./Button"
     name={userName}
-    //props={{name:"BBB"}}
   />
   );
   return (

--- a/test/app1/src/App.tsx
+++ b/test/app1/src/App.tsx
@@ -17,6 +17,7 @@ function App() {
     url="http://localhost:3002/remoteEntry.js"
     scope="app2"
     module="./Button"
+    props={{name : userName}}
   />
   );
   return (

--- a/test/app1/src/App.tsx
+++ b/test/app1/src/App.tsx
@@ -11,21 +11,20 @@ import Button from "./Button";
 function App() {
   const [userName, setName] = useState("");
   const nameEntry = <input value={userName} onChange={event=>setName(event.target.value)}/>
-  const HostButton = () => <Button name={userName}/>;
-  const RemoteButton = () => (
+  const RemoteButton = (props: any) => (
   <RemoteComponent
     url="http://localhost:3002/remoteEntry.js"
     scope="app2"
     module="./Button"
-    name={userName}
+    {...props}
   />
   );
   return (
     <>
       {nameEntry}
-      <HostButton/>
+      <Button name={userName}/>
       <React.Suspense fallback="loading">
-        <RemoteButton/>
+        <RemoteButton name={userName}/>
       </React.Suspense>
       <React.Suspense fallback="loading">
         <InnerApp />

--- a/test/app1/src/App.tsx
+++ b/test/app1/src/App.tsx
@@ -17,7 +17,8 @@ function App() {
     url="http://localhost:3002/remoteEntry.js"
     scope="app2"
     module="./Button"
-    props={{name : userName}}
+    name={userName}
+    //props={{name:"BBB"}}
   />
   );
   return (
@@ -28,61 +29,61 @@ function App() {
         <RemoteButton/>
       </React.Suspense>
       <React.Suspense fallback="loading">
-        <InnerApp />
+        {/* <InnerApp /> */}
       </React.Suspense>
     </>
   );
 }
-
-const remoteModule1 = {
-  url: "http://localhost:3002/remoteEntry.js",
-  scope: "app2",
-  module: "./App",
-};
-
-const remoteModule2 = {
-  url: "http://localhost:3002/remoteEntry.js",
-  scope: "app2",
-  module: "./Button",
-};
-
-getModule({
-  url: "http://localhost:3002/remoteEntry.js",
-  scope: "app2",
-  module: "./App",
-}).then(({ routes }: any) => {
-  //now I have access to the export named 'routes'
-});
-
-const InnerApp = memo(() => {
-  // const t = useRemoteModule(remoteModule1);
-  // const a = useRemoteModule(remoteModule2);
-  // const b = useRemoteModule(remoteModule2);
-  // const c = useRemoteModule(remoteModule2);
-  console.log("render");
-
-  return <></>;
-});
-
 export default App;
+// const remoteModule1 = {
+//   url: "http://localhost:3002/remoteEntry.js",
+//   scope: "app2",
+//   module: "./App",
+// };
 
-class ErrorBoundary extends React.Component {
-  constructor(props: any) {
-    super(props);
-    this.state = { hasError: false };
-  }
+// const remoteModule2 = {
+//   url: "http://localhost:3002/remoteEntry.js",
+//   scope: "app2",
+//   module: "./Button",
+// };
 
-  static getDerivedStateFromError(error: any) {
-    return { hasError: true };
-  }
+// getModule({
+//   url: "http://localhost:3002/remoteEntry.js",
+//   scope: "app2",
+//   module: "./App",
+// }).then(({ routes }: any) => {
+//   //now I have access to the export named 'routes'
+// });
 
-  render() {
-    //@ts-expect-error
-    if (this.state.hasError) {
-      // You can render any custom fallback UI
-      return <h1>Something went wrong.</h1>;
-    }
+// const InnerApp = memo(() => {
+//   // const t = useRemoteModule(remoteModule1);
+//   // const a = useRemoteModule(remoteModule2);
+//   // const b = useRemoteModule(remoteModule2);
+//   // const c = useRemoteModule(remoteModule2);
+//   console.log("render");
 
-    return this.props.children;
-  }
-}
+//   return <></>;
+// });
+
+// export default App;
+
+// class ErrorBoundary extends React.Component {
+//   constructor(props: any) {
+//     super(props);
+//     this.state = { hasError: false };
+//   }
+
+//   static getDerivedStateFromError(error: any) {
+//     return { hasError: true };
+//   }
+
+//   render() {
+//     //@ts-expect-error
+//     if (this.state.hasError) {
+//       // You can render any custom fallback UI
+//       return <h1>Something went wrong.</h1>;
+//     }
+
+//     return this.props.children;
+//   }
+// }

--- a/test/app1/src/App.tsx
+++ b/test/app1/src/App.tsx
@@ -1,21 +1,30 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import Module from "module";
-import React, { memo, useEffect } from "react";
+import React, { memo, useState} from "react";
 import {
   getModule,
   RemoteComponent,
   useRemoteModule,
 } from "react-dynamic-remote-component";
+import Button from "./Button";
 
 function App() {
+  const [userName, setName] = useState("");
+  const nameEntry = <input value={userName} onChange={event=>setName(event.target.value)}/>
+  const HostButton = () => <Button name={userName}/>;
+  const RemoteButton = () => (
+  <RemoteComponent
+    url="http://localhost:3002/remoteEntry.js"
+    scope="app2"
+    module="./Button"
+  />
+  );
   return (
     <>
+      {nameEntry}
+      <HostButton/>
       <React.Suspense fallback="loading">
-        <RemoteComponent
-          url="http://localhost:3002/remoteEntry.js"
-          scope="app2"
-          module="./Button"
-        />
+        <RemoteButton/>
       </React.Suspense>
       <React.Suspense fallback="loading">
         <InnerApp />

--- a/test/app1/src/App.tsx
+++ b/test/app1/src/App.tsx
@@ -28,61 +28,61 @@ function App() {
         <RemoteButton/>
       </React.Suspense>
       <React.Suspense fallback="loading">
-        {/* <InnerApp /> */}
+        <InnerApp />
       </React.Suspense>
     </>
   );
 }
+
+const remoteModule1 = {
+  url: "http://localhost:3002/remoteEntry.js",
+  scope: "app2",
+  module: "./App",
+};
+
+const remoteModule2 = {
+  url: "http://localhost:3002/remoteEntry.js",
+  scope: "app2",
+  module: "./Button",
+};
+
+getModule({
+  url: "http://localhost:3002/remoteEntry.js",
+  scope: "app2",
+  module: "./App",
+}).then(({ routes }: any) => {
+  //now I have access to the export named 'routes'
+});
+
+const InnerApp = memo(() => {
+  // const t = useRemoteModule(remoteModule1);
+  // const a = useRemoteModule(remoteModule2);
+  // const b = useRemoteModule(remoteModule2);
+  // const c = useRemoteModule(remoteModule2);
+  console.log("render");
+
+  return <></>;
+});
+
 export default App;
-// const remoteModule1 = {
-//   url: "http://localhost:3002/remoteEntry.js",
-//   scope: "app2",
-//   module: "./App",
-// };
 
-// const remoteModule2 = {
-//   url: "http://localhost:3002/remoteEntry.js",
-//   scope: "app2",
-//   module: "./Button",
-// };
+class ErrorBoundary extends React.Component {
+  constructor(props: any) {
+    super(props);
+    this.state = { hasError: false };
+  }
 
-// getModule({
-//   url: "http://localhost:3002/remoteEntry.js",
-//   scope: "app2",
-//   module: "./App",
-// }).then(({ routes }: any) => {
-//   //now I have access to the export named 'routes'
-// });
+  static getDerivedStateFromError(error: any) {
+    return { hasError: true };
+  }
 
-// const InnerApp = memo(() => {
-//   // const t = useRemoteModule(remoteModule1);
-//   // const a = useRemoteModule(remoteModule2);
-//   // const b = useRemoteModule(remoteModule2);
-//   // const c = useRemoteModule(remoteModule2);
-//   console.log("render");
+  render() {
+    //@ts-expect-error
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return <h1>Something went wrong.</h1>;
+    }
 
-//   return <></>;
-// });
-
-// export default App;
-
-// class ErrorBoundary extends React.Component {
-//   constructor(props: any) {
-//     super(props);
-//     this.state = { hasError: false };
-//   }
-
-//   static getDerivedStateFromError(error: any) {
-//     return { hasError: true };
-//   }
-
-//   render() {
-//     //@ts-expect-error
-//     if (this.state.hasError) {
-//       // You can render any custom fallback UI
-//       return <h1>Something went wrong.</h1>;
-//     }
-
-//     return this.props.children;
-//   }
-// }
+    return this.props.children;
+  }
+}

--- a/test/app1/src/Button.jsx
+++ b/test/app1/src/Button.jsx
@@ -1,0 +1,3 @@
+const helloFromButton = name => console.log(`App1: Hello ${name}`);
+const Button = (props) => <button onClick={()=>console.log(props.name)}>Hello from app1</button>;
+export default Button;

--- a/test/app1/src/Button.jsx
+++ b/test/app1/src/Button.jsx
@@ -1,3 +1,3 @@
 const helloFromButton = name => console.log(`App1: Hello ${name}`);
-const Button = (props) => <button onClick={()=>console.log(props.name)}>Hello from app1</button>;
+const Button = (props) => <button onClick={()=>helloFromButton(props.name)}>Hello from app1</button>;
 export default Button;

--- a/test/app1/src/Button.tsx
+++ b/test/app1/src/Button.tsx
@@ -1,2 +1,0 @@
-const Button = () => <button>Hello from app1</button>;
-export default Button;

--- a/test/app2/src/App.jsx
+++ b/test/app2/src/App.jsx
@@ -1,6 +1,6 @@
 import Button from "./Button";
 function App() {
-  return <Button />;
+  return <Button name="world!"/>;
 }
 
 export default App;

--- a/test/app2/src/Button/index.jsx
+++ b/test/app2/src/Button/index.jsx
@@ -1,0 +1,5 @@
+import "./style.scss";
+const helloFromButton = name => console.log(`App2: Hello ${name}`);
+const Button = (props) => <button className="funny-button" onClick={()=>helloFromButton(props.name)}>Hello from app2</button>;
+
+export default Button;

--- a/test/app2/src/Button/index.tsx
+++ b/test/app2/src/Button/index.tsx
@@ -1,7 +1,0 @@
-import "./style.scss";
-const Button = () => <button className="funny-button">Hello from app2</button>;
-
-Button.sayHello = () => {
-  console.log("hello");
-};
-export default Button;


### PR DESCRIPTION
Hi here are the implemented changes to pass props and an example to show it working. 

The changes were slightly different from those mentioned in #1 to allow direct passing prop by name, rather than having to pass in an object called props. LMK if you would prefer that though, it's in the branch pass-props-to-remote-component.